### PR TITLE
refactor: implement model management with registry pattern

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,8 @@ import 'package:chibot/l10n/app_localizations.dart';
 import 'dart:io';
 import 'package:tray_manager/tray_manager.dart';
 import 'package:window_manager/window_manager.dart';
+import 'models/model_registry.dart';
+import 'providers/settings_models_provider.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -33,9 +35,17 @@ class MyApp extends StatelessWidget with TrayListener, WindowListener {
 
   @override
   Widget build(BuildContext context) {
-    _initTrayAndWindow(context);
-    return ChangeNotifierProvider(
-      create: (context) => SettingsProvider(),
+    final modelRegistry = ModelRegistry();
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (_) => SettingsProvider(modelRegistry: modelRegistry),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => SettingsModelsProvider(modelRegistry),
+        ),
+        Provider.value(value: modelRegistry),
+      ],
       child: MaterialApp(
         title: "Chi AI Chatbot",
         home: const ChatScreen(),

--- a/lib/models/available_model.dart
+++ b/lib/models/available_model.dart
@@ -1,0 +1,23 @@
+enum ModelType { text, image, customOpenAI }
+
+class AvailableModel {
+  final String id;
+  final String name;
+  final String provider;
+  final ModelType type;
+  final bool supportsStreaming;
+  final Map<String, dynamic> capabilities;
+  final String? baseUrl;
+  final String? apiVersion;
+
+  AvailableModel({
+    required this.id,
+    required this.name,
+    required this.provider,
+    required this.type,
+    this.supportsStreaming = false,
+    this.capabilities = const {},
+    this.baseUrl,
+    this.apiVersion,
+  });
+}

--- a/lib/models/model_registry.dart
+++ b/lib/models/model_registry.dart
@@ -1,0 +1,35 @@
+import 'available_model.dart';
+
+class ModelRegistry {
+  final Map<ModelType, List<AvailableModel>> _models = {
+    ModelType.text: [],
+    ModelType.image: [],
+    ModelType.customOpenAI: [],
+  };
+
+  // 缓存验证时间
+  final Map<String, DateTime> _lastValidated = {};
+  final Duration cacheTtl = const Duration(minutes: 5);
+
+  List<AvailableModel> getModels({required ModelType type}) =>
+      List.unmodifiable(_models[type] ?? []);
+
+  void registerModel(AvailableModel model) {
+    _models[model.type]?.removeWhere((m) => m.id == model.id);
+    _models[model.type]?.add(model);
+    _lastValidated[model.id] = DateTime.now();
+  }
+
+  bool shouldRefresh(String modelId) {
+    final lastValidated = _lastValidated[modelId];
+    return lastValidated == null ||
+        DateTime.now().difference(lastValidated) > cacheTtl;
+  }
+
+  void clear() {
+    for (var type in _models.keys) {
+      _models[type]?.clear();
+    }
+    _lastValidated.clear();
+  }
+}

--- a/lib/providers/model_provider_adapter.dart
+++ b/lib/providers/model_provider_adapter.dart
@@ -1,0 +1,24 @@
+import '../models/available_model.dart';
+import '../models/model_registry.dart';
+
+class ModelProviderAdapter {
+  final ModelRegistry registry;
+
+  ModelProviderAdapter(this.registry);
+
+  List<AvailableModel> getModelsForProvider(String provider) {
+    return registry
+        .getModels(type: ModelType.text)
+        .where((m) => m.provider == provider)
+        .toList();
+  }
+
+  List<AvailableModel> getTextModels() =>
+      registry.getModels(type: ModelType.text);
+
+  List<AvailableModel> getImageModels() =>
+      registry.getModels(type: ModelType.image);
+
+  List<AvailableModel> getCustomModels() =>
+      registry.getModels(type: ModelType.customOpenAI);
+}

--- a/lib/providers/settings_models_provider.dart
+++ b/lib/providers/settings_models_provider.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/foundation.dart';
+import '../models/model_registry.dart';
+import '../models/available_model.dart';
+
+class SettingsModelsProvider extends ChangeNotifier {
+  final ModelRegistry _registry;
+
+  SettingsModelsProvider(this._registry);
+
+  List<AvailableModel> get textModels =>
+      _registry.getModels(type: ModelType.text);
+
+  List<AvailableModel> get imageModels =>
+      _registry.getModels(type: ModelType.image);
+
+  List<AvailableModel> get customModels =>
+      _registry.getModels(type: ModelType.customOpenAI);
+
+  // 可扩展：刷新、验证、通知等
+  void refreshModels() {
+    // TODO: 实现模型刷新逻辑
+    notifyListeners();
+  }
+}

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -20,11 +20,11 @@ import 'package:chibot/l10n/app_localizations.dart';
 import 'settings_screen.dart';
 import 'about_screen.dart';
 import 'package:chibot/services/web_search_service.dart' as web_service;
-import 'package:chibot/services/search_command_handler.dart';
 import 'update_dialog.dart';
 import '../services/update_service.dart';
 import 'package:flutter/services.dart'; // For Clipboard
 import 'package:chibot/services/search_service_manager.dart';
+import 'package:chibot/models/available_model.dart' as available_model;
 
 class ChatScreen extends StatefulWidget {
   const ChatScreen({super.key});
@@ -77,7 +77,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
   void _startNewChat() {
     final settings = Provider.of<SettingsProvider>(context, listen: false);
-    settings.setSelectedModelType(ModelType.text);
+    settings.setSelectedModelType(available_model.ModelType.text);
     setState(() {
       _messages.clear();
       _currentSessionId = null;
@@ -97,7 +97,7 @@ class _ChatScreenState extends State<ChatScreen> {
 
   void _startNewImageSession() {
     final settings = Provider.of<SettingsProvider>(context, listen: false);
-    settings.setSelectedModelType(ModelType.image);
+    settings.setSelectedModelType(available_model.ModelType.image);
     setState(() {
       _messages.clear();
       _currentImageSessionId = null;
@@ -120,7 +120,7 @@ class _ChatScreenState extends State<ChatScreen> {
     if (text.isEmpty) return;
 
     final settings = Provider.of<SettingsProvider>(context, listen: false);
-    if (settings.selectedModelType == ModelType.image) {
+    if (settings.selectedModelType == available_model.ModelType.image) {
       _generateImage(text);
       _textController.clear();
       return;
@@ -1374,7 +1374,8 @@ class _ChatScreenState extends State<ChatScreen> {
                       child: Consumer<SettingsProvider>(
                         builder: (context, settings, _) {
                           final isTextModel =
-                              settings.selectedModelType == ModelType.text;
+                              settings.selectedModelType ==
+                              available_model.ModelType.text;
                           final isActive = isTextModel && _enableWebSearch;
                           return Ink(
                             decoration: BoxDecoration(


### PR DESCRIPTION
- Add ModelRegistry to centralize model management and caching
- Create AvailableModel data structure with provider and capability metadata
- Implement SettingsModelsProvider for reactive model state management
- Refactor settings screen to use registry-based model selection
- Update provider architecture to support MultiProvider pattern
- Add model synchronization between settings and registry

🤖 Generated with [Claude Code](https://claude.ai/code)